### PR TITLE
chore: Bump keycloak from 22.0.4 to 22.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.4
+FROM quay.io/keycloak/keycloak:22.0.5
 
 # Enable health and metrics support
 ENV KC_HEALTH_ENABLED=true


### PR DESCRIPTION
Small version bump.